### PR TITLE
Fixed 100% CPU usage when reloading SQUID configuration or rotating S…

### DIFF
--- a/squid_dedup/dedup.py
+++ b/squid_dedup/dedup.py
@@ -114,4 +114,7 @@ class Dedup:
                             open(self._protocol, 'a').write(line + '\n' + ' '.join(args) + '\n')
                         except IOError as e:
                             log.error('protocol logging error: %s', e)
+                else:
+                    log.error('sys.stdin.readline() is false. Ending the process.')
+                    break
         log.debug('finished')

--- a/squid_dedup/main.py
+++ b/squid_dedup/main.py
@@ -90,7 +90,10 @@ class Main(object):
                 self.start_threads()
                 log.trace(self._config)
                 self._reload = False
-        log.info('finished')
+            if not self._threads[0][1].is_alive():
+               log.error('dedup thread terminated. Exiting')
+               self.shutdown()
+        log.info('finished (%s)', os.getpid())
         return ret
 
 


### PR DESCRIPTION
SQUID, when executing a reload or rotate command, does not kill helper processes, but spawns new processes. At the same time, old processes begin to load the processor core at 100%. Apparently, there is something going on with the stdin socket.
I added a small crutch so that the helper process would catch the moment when stdin breaks and exit.